### PR TITLE
Lazily create the vagrant path

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -189,6 +189,8 @@ module Beaker
     end
 
     def set_ssh_config host, user
+      return unless Dir.exist?(@vagrant_path)
+
       f = Tempfile.new("#{host.name}")
       ssh_config = Dir.chdir(@vagrant_path) do
         stdin, stdout, stderr, wait_thr = Open3.popen3(@vagrant_env, 'vagrant', 'ssh-config', host.name)

--- a/lib/beaker/hypervisor/vagrant_custom.rb
+++ b/lib/beaker/hypervisor/vagrant_custom.rb
@@ -6,6 +6,7 @@ class Beaker::VagrantCustom < Beaker::Vagrant
   end
 
   def make_vfile hosts, options = {}
+    FileUtils.mkdir_p(@vagrant_path)
     FileUtils.cp(@options[:vagrantfile_path], @vagrant_file)
   end
 end

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -480,7 +480,8 @@ EOF
       end
 
       it "can generate a ssh-config file" do
-       expect( Tempfile ).to receive( :new ).with( "#{host.name}").and_return( file )
+        expect( Tempfile ).to receive( :new ).with( "#{host.name}").and_return( file )
+        expect( Dir ).to receive( :exist? ).with( '/.vagrant/beaker_vagrant_files/beaker_sample.cfg' ).and_return( true )
         expect( file ).to receive( :write ).with("Host ip.address.for.#{name}\n        HostName 127.0.0.1\n        User root\n        Port 2222\n        UserKnownHostsFile /dev/null\n        StrictHostKeyChecking no\n        PasswordAuthentication no\n        IdentityFile /home/root/.vagrant.d/insecure_private_key\n        IdentitiesOnly no")
 
         vagrant.set_ssh_config( host, 'root' )
@@ -496,6 +497,7 @@ EOF
           options = vagrant.instance_variable_set( :@options, options )
 
           expect( Tempfile ).to receive( :new ).with( "#{host.name}").and_return( file )
+          expect( Dir ).to receive( :exist? ).with( '/.vagrant/beaker_vagrant_files/beaker_sample.cfg' ).and_return( true )
           expect( file ).to receive( :write ).with("Host ip.address.for.#{name}\n        HostName 127.0.0.1\n        User root\n        Port 2222\n        UserKnownHostsFile /dev/null\n        StrictHostKeyChecking no\n        PasswordAuthentication no\n        IdentityFile /home/root/.vagrant.d/insecure_private_key\n        IdentitiesOnly yes")
 
           vagrant.set_ssh_config( host, 'root' )


### PR DESCRIPTION
It's a good practice to only create something if you're going to use it. This also makes it easier to unit test individual components of the hypervisor.