### PR TITLE
Remove redundant path in path construction

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -242,7 +242,7 @@ module Beaker
       @logger = options[:logger]
       @temp_files = []
       @hosts = vagrant_hosts
-      @vagrant_path = File.expand_path(File.join(File.basename(__FILE__), '..', '.vagrant', 'beaker_vagrant_files', 'beaker_' + File.basename(options[:hosts_file])))
+      @vagrant_path = File.expand_path(File.join('.vagrant', 'beaker_vagrant_files', 'beaker_' + File.basename(options[:hosts_file])))
       @vagrant_file = File.expand_path(File.join(@vagrant_path, "Vagrantfile"))
       @vagrant_env = { "RUBYLIB" => "", "RUBYOPT" => "" }
     end


### PR DESCRIPTION
In this case `File.basename(__FILE__)` returns `vagrant`. Then the next part is `..` which cancels out the first part thanks to `File.expand_path`.