### PR TITLE
Correctly override the Vagrant path

### DIFF
--- a/lib/beaker/hypervisor/vagrant_libvirt.rb
+++ b/lib/beaker/hypervisor/vagrant_libvirt.rb
@@ -1,13 +1,17 @@
 require 'beaker/hypervisor/vagrant'
 
 class Beaker::VagrantLibvirt < Beaker::Vagrant
-  def provision(provider = 'libvirt')
+  def initialize(*)
+    super
+
     # This needs to be unique for every system with the same hostname but does
     # not affect VirtualBox
     vagrant_path_digest = Digest::SHA256.hexdigest(@vagrant_path)
-    @vagrant_path = @vagrant_path + '_' + vagrant_path_digest[0..2] + vagrant_path_digest[-3..-1]
+    @vagrant_path += '_' + vagrant_path_digest[0..2] + vagrant_path_digest[-3..-1]
     @vagrant_file = File.expand_path(File.join(@vagrant_path, "Vagrantfile"))
+  end
 
+  def provision(provider = 'libvirt')
     super
   end
 


### PR DESCRIPTION
In b162e77b2f8c8f465a6267385c5a7d3f1a2d2bda the path was updated to make the path unique. However, it's done in the provisioning step. That's the wrong time. If `BEAKER_provision=no` is passed, no provisioning happens and the path is incorrect. By overriding the initializer, it always happens.

Fixes: b162e77b2f8c8f465a6267385c5a7d3f1a2d2bda