### PR TITLE
Stop using private networks on libvirt

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -54,7 +54,7 @@ module Beaker
 
       hosts.each do |host|
         host.name.tr!('_','-') # Rewrite Hostname with hyphens instead of underscores to get legal hostname
-        host['ip'] ||= randip(host.host_hash[:hypervisor]) #use the existing ip, otherwise default to a random ip
+        set_host_default_ip(host)
         v_file << "  c.vm.define '#{host.name}' do |v|\n"
         v_file << "    v.vm.hostname = '#{host.name}'\n"
         v_file << "    v.vm.box = '#{host['box']}'\n"
@@ -64,7 +64,7 @@ module Beaker
         v_file << "    v.vm.box_check_update = '#{host['box_check_update'] ||= 'true'}'\n"
         v_file << "    v.vm.synced_folder '.', '/vagrant', disabled: true\n" if host['synced_folder'] == 'disabled'
         v_file << shell_provisioner_generator(host['shell_provisioner']) if host['shell_provisioner']
-        v_file << private_network_generator(host)
+        v_file << private_network_generator(host) if host['ip']
 
         unless host['mount_folders'].nil?
           host['mount_folders'].each do |name, folder|
@@ -310,6 +310,12 @@ module Beaker
           '1024'
         end
       end
+    end
+
+    private
+
+    def set_host_default_ip(host)
+      host['ip'] ||= randip(host.host_hash[:hypervisor]) # use the existing ip, otherwise default to a random ip
     end
   end
 end

--- a/lib/beaker/hypervisor/vagrant_libvirt.rb
+++ b/lib/beaker/hypervisor/vagrant_libvirt.rb
@@ -25,4 +25,10 @@ class Beaker::VagrantLibvirt < Beaker::Vagrant
 
     options['libvirt'].map { |k, v| "      node.#{k} = '#{v}'" }
   end
+
+  private
+
+  def set_host_default_ip(host)
+    # In vagrant-libvirt hosts get a management IP, no need for a default
+  end
 end

--- a/spec/beaker/hypervisor/vagrant_fusion_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_fusion_spec.rb
@@ -2,30 +2,31 @@ require 'spec_helper'
 
 describe Beaker::VagrantFusion do
   let( :options ) { make_opts.merge({ :hosts_file => 'sample.cfg', 'logger' => double().as_null_object }) }
-  let( :vagrant ) { Beaker::VagrantFusion.new( @hosts, options ) }
-
-  before :each do
-    @hosts = make_hosts()
-  end
+  let( :vagrant ) { described_class.new( hosts, options ) }
+  let( :hosts ) { make_hosts() }
 
   it "uses the vmware_fusion provider for provisioning" do
-    @hosts.each do |host|
+    hosts.each do |host|
       host_prev_name = host['user']
       expect( vagrant ).to receive( :set_ssh_config ).with( host, 'vagrant' ).once
       expect( vagrant ).to receive( :copy_ssh_to_root ).with( host, options ).once
       expect( vagrant ).to receive( :set_ssh_config ).with( host, host_prev_name ).once
     end
-    expect( vagrant ).to receive( :hack_etc_hosts ).with( @hosts, options ).once
+    expect( vagrant ).to receive( :hack_etc_hosts ).with( hosts, options ).once
     expect( vagrant ).to receive( :vagrant_cmd ).with( "up --provider vmware_fusion" ).once
     vagrant.provision
   end
 
-  it "can make a Vagranfile for a set of hosts" do
-    path = vagrant.instance_variable_get( :@vagrant_path )
+  context 'Correct vagrant configuration' do
+    subject do
+      FakeFS do
+        vagrant.make_vfile( hosts, options )
+        File.read(vagrant.instance_variable_get(:@vagrant_file))
+      end
+    end
 
-    vagrant.make_vfile( @hosts )
-
-    vagrantfile = File.read( File.expand_path( File.join( path, "Vagrantfile")))
-    expect( vagrantfile ).to include( %Q{    v.vm.provider :vmware_fusion do |v|\n      v.vmx['memsize'] = '1024'\n    end})
+    it 'has a provider section' do
+      is_expected.to include( %Q{    v.vm.provider :vmware_fusion do |v|\n      v.vmx['memsize'] = '1024'\n    end})
+    end
   end
 end

--- a/spec/beaker/hypervisor/vagrant_libvirt_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_libvirt_spec.rb
@@ -39,6 +39,10 @@ describe Beaker::VagrantLibvirt do
       is_expected.to include( %Q{    v.vm.provider :libvirt do |node|})
     end
 
+    it "has no private network" do
+      is_expected.not_to include('v.vm.network :private_network')
+    end
+
     it "can specify the memory as an integer" do
       is_expected.to include('node.memory = 1024')
     end

--- a/spec/beaker/hypervisor/vagrant_libvirt_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_libvirt_spec.rb
@@ -6,20 +6,21 @@ describe Beaker::VagrantLibvirt do
                                       'libvirt' => { 'uri' => 'qemu+ssh://root@host/system'},
                                       'vagrant_cpus' => 2,
                                     }) }
-  let( :vagrant ) { Beaker::VagrantLibvirt.new( @hosts, options ) }
-
-  before :each do
-    @hosts = make_hosts()
+  let( :vagrant ) { described_class.new( hosts, options ) }
+  let( :hosts ) do
+    make_hosts().each do |host|
+      host.delete('ip')
+    end
   end
 
   it "uses the vagrant_libvirt provider for provisioning" do
-    @hosts.each do |host|
+    hosts.each do |host|
       host_prev_name = host['user']
       expect( vagrant ).to receive( :set_ssh_config ).with( host, 'vagrant' ).once
       expect( vagrant ).to receive( :copy_ssh_to_root ).with( host, options ).once
       expect( vagrant ).to receive( :set_ssh_config ).with( host, host_prev_name ).once
     end
-    expect( vagrant ).to receive( :hack_etc_hosts ).with( @hosts, options ).once
+    expect( vagrant ).to receive( :hack_etc_hosts ).with( hosts, options ).once
     expect( vagrant ).to receive( :vagrant_cmd ).with( "up --provider libvirt" ).once
     FakeFS do
       vagrant.provision
@@ -27,32 +28,27 @@ describe Beaker::VagrantLibvirt do
   end
 
   context 'Correct vagrant configuration' do
-    before(:each) do
+    subject do
       FakeFS do
-        path = vagrant.instance_variable_get( :@vagrant_path )
-
-        vagrant.make_vfile( @hosts, options )
-        @vagrantfile = File.read( File.expand_path( File.join( path, "Vagrantfile")))
+        vagrant.make_vfile( hosts, options )
+        File.read(vagrant.instance_variable_get(:@vagrant_file))
       end
     end
 
-    it "can make a Vagranfile for a set of hosts" do
-      expect( @vagrantfile ).to include( %Q{    v.vm.provider :libvirt do |node|})
+    it 'has a provider section' do
+      is_expected.to include( %Q{    v.vm.provider :libvirt do |node|})
     end
 
     it "can specify the memory as an integer" do
-      expect( @vagrantfile.split("\n").map(&:strip) )
-        .to include('node.memory = 1024')
+      is_expected.to include('node.memory = 1024')
     end
 
     it "can specify the number of cpus" do
-      expect( @vagrantfile.split("\n").map(&:strip) )
-        .to include("node.cpus = 2")
+      is_expected.to include("node.cpus = 2")
     end
 
     it "can specify any libvirt option" do
-      expect( @vagrantfile.split("\n").map(&:strip) )
-        .to include("node.uri = 'qemu+ssh://root@host/system'")
+      is_expected.to include("node.uri = 'qemu+ssh://root@host/system'")
     end
   end
 end

--- a/spec/beaker/hypervisor/vagrant_parallels_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_parallels_spec.rb
@@ -2,42 +2,40 @@ require 'spec_helper'
 
 describe Beaker::VagrantParallels do
   let( :options ) { make_opts.merge({ :hosts_file => 'sample.cfg', 'logger' => double().as_null_object }) }
-  let( :vagrant ) { Beaker::VagrantParallels.new( @hosts, options ) }
-
-  before :each do
-    @hosts = make_hosts()
-  end
+  let( :vagrant ) { Beaker::VagrantParallels.new( hosts, options ) }
+  let( :hosts ) { make_hosts }
 
   it "uses the parallels provider for provisioning" do
-    @hosts.each do |host|
+    hosts.each do |host|
       host_prev_name = host['user']
       expect( vagrant ).to receive( :set_ssh_config ).with( host, 'vagrant' ).once
       expect( vagrant ).to receive( :copy_ssh_to_root ).with( host, options ).once
       expect( vagrant ).to receive( :set_ssh_config ).with( host, host_prev_name ).once
     end
-    expect( vagrant ).to receive( :hack_etc_hosts ).with( @hosts, options ).once
+    expect( vagrant ).to receive( :hack_etc_hosts ).with( hosts, options ).once
     expect( vagrant ).to receive( :vagrant_cmd ).with( "up --provider parallels" ).once
     vagrant.provision
   end
 
-  it "can make a Vagranfile for a set of hosts" do
-    path = vagrant.instance_variable_get( :@vagrant_path )
+  context 'Correct vagrant configuration' do
+    subject do
+      FakeFS do
+        vagrant.make_vfile( hosts, options )
+        File.read(vagrant.instance_variable_get(:@vagrant_file))
+      end
+    end
 
-    vagrant.make_vfile( @hosts )
-
-    vagrantfile = File.read( File.expand_path( File.join( path, 'Vagrantfile' )))
-    expect( vagrantfile ).to include( %Q{    v.vm.provider :parallels do |prl|\n      prl.optimize_power_consumption = false\n      prl.memory = '1024'\n    end})
+    it "can make a Vagrantfile for a set of hosts" do
+      is_expected.to include( %Q{    v.vm.provider :parallels do |prl|\n      prl.optimize_power_consumption = false\n      prl.memory = '1024'\n    end})
+    end
   end
 
-  it "can disable the auto-update functionality of the Parallels Guest Tools" do
-    options.merge!({ :prl_update_guest_tools => 'disable' })
+  context 'disabled guest tools' do
+    let(:options) { super().merge({ :prl_update_guest_tools => 'disable' }) }
+    subject { vagrant.class.provider_vfile_section( hosts.first, options ) }
 
-    vfile_section = vagrant.class.provider_vfile_section( @hosts.first, options )
-
-    match = vfile_section.match(/prl.update_guest_tools = false/)
-
-    expect( match ).to_not be nil
-
+    it "can disable the auto-update functionality of the Parallels Guest Tools" do
+      is_expected.to match(/prl.update_guest_tools = false/)
+    end
   end
-
 end

--- a/spec/beaker/hypervisor/vagrant_virtualbox_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_virtualbox_spec.rb
@@ -2,98 +2,77 @@ require 'spec_helper'
 
 describe Beaker::VagrantVirtualbox do
   let( :options ) { make_opts.merge({ :hosts_file => 'sample.cfg', 'logger' => double().as_null_object }) }
-  let( :vagrant ) { Beaker::VagrantVirtualbox.new( @hosts, options ) }
-  let(:vagrantfile_path) do
-    path = vagrant.instance_variable_get( :@vagrant_path )
-    File.expand_path( File.join( path, 'Vagrantfile' ))
-  end
-
-  before :each do
-    @hosts = make_hosts()
-  end
+  let( :vagrant ) { described_class.new( hosts, options ) }
+  let(:vagrantfile_path) { vagrant.instance_variable_get( :@vagrant_file ) }
+  let(:hosts) { make_hosts() }
 
   it "uses the virtualbox provider for provisioning" do
-    @hosts.each do |host|
+    hosts.each do |host|
       host_prev_name = host['user']
       expect( vagrant ).to receive( :set_ssh_config ).with( host, 'vagrant' ).once
       expect( vagrant ).to receive( :copy_ssh_to_root ).with( host, options ).once
       expect( vagrant ).to receive( :set_ssh_config ).with( host, host_prev_name ).once
     end
-    expect( vagrant ).to receive( :hack_etc_hosts ).with( @hosts, options ).once
+    expect( vagrant ).to receive( :hack_etc_hosts ).with( hosts, options ).once
     expect( vagrant ).to receive( :vagrant_cmd ).with( "up --provider virtualbox" ).once
     vagrant.provision
   end
 
-  it "can make a Vagranfile for a set of hosts" do
-    path = vagrant.instance_variable_get( :@vagrant_path )
+  context 'can make a Vagrantfile' do
+    subject do
+      FakeFS do
+        vagrant.make_vfile(hosts)
+        File.read(vagrant.instance_variable_get(:@vagrant_file))
+      end
+    end
 
-    vagrant.make_vfile( @hosts )
+    it "can make a Vagrantfile for a set of hosts" do
+      is_expected.to include( %Q{    v.vm.provider :virtualbox do |vb|\n      vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1', '--audio', 'none']\n    end})
+    end
 
-    vagrantfile = File.read( File.expand_path( File.join( path, 'Vagrantfile' )))
-    expect( vagrantfile ).to include( %Q{    v.vm.provider :virtualbox do |vb|\n      vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1', '--audio', 'none']\n    end})
+    context 'with ioapic(multiple cores)' do
+      let(:hosts) { make_hosts({:ioapic => 'true'}, 1) }
+
+      it { is_expected.to include( " vb.customize ['modifyvm', :id, '--ioapic', 'on']") }
+    end
+
+    context 'with NAT DNS' do
+      let(:hosts) { make_hosts({:natdns => 'on'}, 1) }
+
+      it { is_expected.to include( " vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']") }
+      it { is_expected.to include( " vb.customize ['modifyvm', :id, '--natdnsproxy1', 'on']") }
+    end
+
+    context 'storage with the USB controller' do
+      let(:hosts) { make_hosts({:volumes => { 'test_disk' => { size: '5120' }}, :volume_storage_controller => 'USB' }) }
+
+      it { is_expected.to include(" vb.customize ['modifyvm', :id, '--usb', 'on']") }
+      it { is_expected.to include(" vb.customize ['storagectl', :id, '--name', 'Beaker USB Controller', '--add', 'usb', '--portcount', '8', '--controller', 'USB', '--bootable', 'off']") }
+      it { is_expected.to include(" vb.customize ['createhd', '--filename', 'vm1-test_disk.vdi', '--size', '5120']") }
+      it { is_expected.to include(" vb.customize ['storageattach', :id, '--storagectl', 'Beaker USB Controller', '--port', '0', '--device', '0', '--type', 'hdd', '--medium', 'vm1-test_disk.vdi']") }
+    end
+
+    context 'storage with the LSILogic controller' do
+      let(:hosts) { make_hosts({:volumes => { 'test_disk' => { size: '5120' }}, :volume_storage_controller => 'LSILogic' }) }
+
+      it { is_expected.to include(" vb.customize ['storagectl', :id, '--name', 'Beaker LSILogic Controller', '--add', 'scsi', '--portcount', '16', '--controller', 'LSILogic', '--bootable', 'off']") }
+      it { is_expected.to include(" vb.customize ['createhd', '--filename', 'vm1-test_disk.vdi', '--size', '5120']") }
+      it { is_expected.to include(" vb.customize ['storageattach', :id, '--storagectl', 'Beaker LSILogic Controller', '--port', '0', '--device', '0', '--type', 'hdd', '--medium', 'vm1-test_disk.vdi']") }
+    end
+
+    context "storage with the default controller" do
+      let(:hosts) { make_hosts({:volumes => { 'test_disk' => { size: '5120' }}}) }
+
+      it { is_expected.to include(" vb.customize ['storagectl', :id, '--name', 'Beaker IntelAHCI Controller', '--add', 'sata', '--portcount', '2', '--controller', 'IntelAHCI', '--bootable', 'off']") }
+      it { is_expected.to include(" vb.customize ['createhd', '--filename', 'vm1-test_disk.vdi', '--size', '5120']") }
+      it { is_expected.to include(" vb.customize ['storageattach', :id, '--storagectl', 'Beaker IntelAHCI Controller', '--port', '0', '--device', '0', '--type', 'hdd', '--medium', 'vm1-test_disk.vdi']") }
+    end
   end
 
-  it "can disable the vb guest plugin" do
-    options.merge!({ :vbguest_plugin => 'disable' })
+  context 'disabled vb guest plugin' do
+    let(:options) { super().merge({ :vbguest_plugin => 'disable' }) }
+    subject { vagrant.class.provider_vfile_section( hosts.first, options ) }
 
-    vfile_section = vagrant.class.provider_vfile_section( @hosts.first, options )
-
-    match = vfile_section.match(/vb.vbguest.auto_update = false/)
-
-    expect( match ).to_not be nil
-
-  end
-
-  it "can enable ioapic(multiple cores) on hosts" do
-    path = vagrant.instance_variable_get( :@vagrant_path )
-    hosts = make_hosts({:ioapic => 'true'},1)
-
-    vagrant.make_vfile( hosts )
-
-    vagrantfile = File.read( File.expand_path( File.join( path, 'Vagrantfile' )))
-    expect( vagrantfile ).to include( " vb.customize ['modifyvm', :id, '--ioapic', 'on']")
-  end
-
-  it "can enable NAT DNS on hosts" do
-    hosts = make_hosts({:natdns => 'on'},1)
-    vagrant.make_vfile( hosts )
-    vagrantfile = File.read( vagrantfile_path )
-
-    expect( vagrantfile ).to include( " vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']")
-    expect( vagrantfile ).to include( " vb.customize ['modifyvm', :id, '--natdnsproxy1', 'on']")
-  end
-
-  it "correctly provisions storage with the USB controller" do
-    path = vagrant.instance_variable_get( :@vagrant_path )
-    hosts = make_hosts({:volumes => { 'test_disk' => { size: '5120' }}, :volume_storage_controller => 'USB' })
-
-    vagrant.make_vfile( hosts )
-    vagrantfile = File.read( File.expand_path( File.join( path, 'Vagrantfile' )))
-    expect( vagrantfile ).to include(" vb.customize ['modifyvm', :id, '--usb', 'on']")
-    expect( vagrantfile ).to include(" vb.customize ['storagectl', :id, '--name', 'Beaker USB Controller', '--add', 'usb', '--portcount', '8', '--controller', 'USB', '--bootable', 'off']")
-    expect( vagrantfile ).to include(" vb.customize ['createhd', '--filename', 'vm1-test_disk.vdi', '--size', '5120']")
-    expect( vagrantfile ).to include(" vb.customize ['storageattach', :id, '--storagectl', 'Beaker USB Controller', '--port', '0', '--device', '0', '--type', 'hdd', '--medium', 'vm1-test_disk.vdi']")
-  end
-
-  it "correctly provisions storage with the LSILogic controller" do
-    path = vagrant.instance_variable_get( :@vagrant_path )
-    hosts = make_hosts({:volumes => { 'test_disk' => { size: '5120' }}, :volume_storage_controller => 'LSILogic' })
-
-    vagrant.make_vfile( hosts )
-    vagrantfile = File.read( File.expand_path( File.join( path, 'Vagrantfile' )))
-    expect( vagrantfile ).to include(" vb.customize ['storagectl', :id, '--name', 'Beaker LSILogic Controller', '--add', 'scsi', '--portcount', '16', '--controller', 'LSILogic', '--bootable', 'off']")
-    expect( vagrantfile ).to include(" vb.customize ['createhd', '--filename', 'vm1-test_disk.vdi', '--size', '5120']")
-    expect( vagrantfile ).to include(" vb.customize ['storageattach', :id, '--storagectl', 'Beaker LSILogic Controller', '--port', '0', '--device', '0', '--type', 'hdd', '--medium', 'vm1-test_disk.vdi']")
-  end
-
-  it "correctly provisions storage with the default controller" do
-    path = vagrant.instance_variable_get( :@vagrant_path )
-    hosts = make_hosts({:volumes => { 'test_disk' => { size: '5120' }}})
-
-    vagrant.make_vfile( hosts )
-    vagrantfile = File.read( File.expand_path( File.join( path, 'Vagrantfile' )))
-    expect( vagrantfile ).to include(" vb.customize ['storagectl', :id, '--name', 'Beaker IntelAHCI Controller', '--add', 'sata', '--portcount', '2', '--controller', 'IntelAHCI', '--bootable', 'off']")
-    expect( vagrantfile ).to include(" vb.customize ['createhd', '--filename', 'vm1-test_disk.vdi', '--size', '5120']")
-    expect( vagrantfile ).to include(" vb.customize ['storageattach', :id, '--storagectl', 'Beaker IntelAHCI Controller', '--port', '0', '--device', '0', '--type', 'hdd', '--medium', 'vm1-test_disk.vdi']")
+    it { is_expected.to match(/vb\.vbguest\.auto_update = false/) }
   end
 end

--- a/spec/beaker/hypervisor/vagrant_workstation_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_workstation_spec.rb
@@ -2,70 +2,57 @@ require 'spec_helper'
 
 describe Beaker::VagrantWorkstation do
   let( :options ) { make_opts.merge({ :hosts_file => 'sample.cfg', 'logger' => double().as_null_object }) }
-  let( :vagrant ) { Beaker::VagrantWorkstation.new( @hosts, options ) }
-
-  before :each do
-    @hosts = make_hosts()
-  end
+  let( :vagrant ) { described_class.new( hosts, options ) }
+  let( :hosts ) { make_hosts() }
 
   it "uses the vmware_workstation provider for provisioning" do
-    @hosts.each do |host|
+    hosts.each do |host|
       host_prev_name = host['user']
       expect( vagrant ).to receive( :set_ssh_config ).with( host, 'vagrant' ).once
       expect( vagrant ).to receive( :copy_ssh_to_root ).with( host, options ).once
       expect( vagrant ).to receive( :set_ssh_config ).with( host, host_prev_name ).once
     end
-    expect( vagrant ).to receive( :hack_etc_hosts ).with( @hosts, options ).once
+    expect( vagrant ).to receive( :hack_etc_hosts ).with( hosts, options ).once
     expect( vagrant ).to receive( :vagrant_cmd ).with( "up --provider vmware_workstation" ).once
-    vagrant.provision
+    FakeFS do
+      vagrant.provision
+    end
   end
 
-  it "can make a Vagranfile for a set of hosts" do
-    path = vagrant.instance_variable_get( :@vagrant_path )
+  context 'can make a Vagrantfile' do
+    subject do
+      FakeFS do
+        vagrant.make_vfile(hosts)
+        File.read(vagrant.instance_variable_get(:@vagrant_file))
+      end
+    end
 
-    vagrant.make_vfile( @hosts )
+    it "for a set of hosts" do
+      is_expected.to include( %Q{    v.vm.provider :vmware_workstation do |v|\n      v.vmx['memsize'] = '1024'\n    end})
+    end
 
-    vagrantfile = File.read( File.expand_path( File.join( path, "Vagrantfile")))
-    expect( vagrantfile ).to include( %Q{    v.vm.provider :vmware_workstation do |v|\n      v.vmx['memsize'] = '1024'\n    end})
-  end
+    context 'with whitelist_verified' do
+      let(:hosts) { make_hosts({:whitelist_verified => true}, 1) }
 
-  it "can enable whitelist_verified on hosts" do 
-    path = vagrant.instance_variable_get( :@vagrant_path )
-    hosts = make_hosts({:whitelist_verified => true},1)
+      it { is_expected.to include( %Q{ v.vmx['whitelist_verified'] = 'true'}) }
+    end
 
-    vagrant.make_vfile( hosts )
+    context 'with functional_hgfs' do
+      let(:hosts) { make_hosts({:functional_hgfs => true}, 1) }
 
-    vagrantfile = File.read( File.expand_path( File.join( path, 'Vagrantfile' )))
-    expect( vagrantfile ).to include( %Q{ v.vmx['whitelist_verified'] = 'true'})
-  end
+      it { is_expected.to include( %Q{ v.vmx['functional_hgfs'] = 'true'}) }
+    end
 
-  it "can enable functional_hgfs on hosts" do 
-    path = vagrant.instance_variable_get( :@vagrant_path )
-    hosts = make_hosts({:functional_hgfs => true},1)
+    context 'with unmount_default_hgfs' do
+      let(:hosts) { make_hosts({:unmount_default_hgfs => true}, 1) }
 
-    vagrant.make_vfile( hosts )
+      it { is_expected.to include( %Q{ v.vmx['unmount_default_hgfs'] = 'true'}) }
+    end
 
-    vagrantfile = File.read( File.expand_path( File.join( path, 'Vagrantfile' )))
-    expect( vagrantfile ).to include( %Q{ v.vmx['functional_hgfs'] = 'true'})
-  end
+    context "with gui" do
+      let(:hosts) { make_hosts({:gui => true},1) }
 
-  it "can enable unmount_default_hgfs on hosts" do 
-    path = vagrant.instance_variable_get( :@vagrant_path )
-    hosts = make_hosts({:unmount_default_hgfs => true},1)
-
-    vagrant.make_vfile( hosts )
-
-    vagrantfile = File.read( File.expand_path( File.join( path, 'Vagrantfile' )))
-    expect( vagrantfile ).to include( %Q{ v.vmx['unmount_default_hgfs'] = 'true'})
-  end
-
-  it "can enable gui on hosts" do 
-    path = vagrant.instance_variable_get( :@vagrant_path )
-    hosts = make_hosts({:gui => true},1)
-
-    vagrant.make_vfile( hosts )
-
-    vagrantfile = File.read( File.expand_path( File.join( path, 'Vagrantfile' )))
-    expect( vagrantfile ).to include( %Q{ v.vmx['gui'] = true})
+      it { is_expected.to include( %Q{ v.vmx['gui'] = true}) }
+    end
   end
 end


### PR DESCRIPTION
Vagrant already has management network by default. Also using a private network creates 2 networks and that often creates routing issues between the host and the guest. This implementation makes the private network generator optional if no IP is set. This keeps it backwards compatible.