### PR TITLE
Remove set_host_default from vagrant_libvirt

### DIFF
--- a/lib/beaker/hypervisor/vagrant_libvirt.rb
+++ b/lib/beaker/hypervisor/vagrant_libvirt.rb
@@ -29,10 +29,4 @@ class Beaker::VagrantLibvirt < Beaker::Vagrant
 
     options['libvirt'].map { |k, v| "      node.#{k} = '#{v}'" }
   end
-
-  private
-
-  def set_host_default_ip(host)
-    # In vagrant-libvirt hosts get a management IP, no need for a default
-  end
 end

--- a/spec/beaker/hypervisor/vagrant_libvirt_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_libvirt_spec.rb
@@ -40,7 +40,7 @@ describe Beaker::VagrantLibvirt do
     end
 
     it "has no private network" do
-      is_expected.not_to include('v.vm.network :private_network')
+      is_expected.to include('v.vm.network :private_network')
     end
 
     it "can specify the memory as an integer" do


### PR DESCRIPTION
The previous change broke the proper update of /etc/hosts by beaker
which, in turn, broke multi-node testing.

Fixes: #49