### PR TITLE
Use Bundler to clean the environment

### DIFF
--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -433,8 +433,7 @@ module Beaker
           vagrant.instance_variable_set(:@vagrant_path, dir)
           state = double('state')
           allow(state).to receive(:success?).and_return(true)
-          allow(Open3).to receive(:capture3).with({ 'RUBYLIB' => '', 'RUBYOPT' => '' }, 'vagrant', 'ssh-config',
-                                                  name).and_return([out, '', state])
+          allow(Open3).to receive(:capture3).with({}, 'vagrant', 'ssh-config', name).and_return([out, '', state])
 
           vagrant.set_ssh_config(host, 'root')
         end


### PR DESCRIPTION
After updating to Fedora 38 (which includes Ruby 3.2 and Bundler 2.4) I started to need this. Perhaps it's also a bug in the system wide vagrant installation to not prune it, but Bundler provides a way to run with all bundler-related variables removed. Since there was already some code to try this, it now goes the whole way.