### PR TITLE
Allow beaker 4 again

### DIFF
--- a/beaker-vagrant.gemspec
+++ b/beaker-vagrant.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'voxpupuli-rubocop', '~> 1.1'
 
-  s.add_runtime_dependency 'beaker', '~> 5'
+  s.add_runtime_dependency 'beaker', '>= 4', '< 6'
 end


### PR DESCRIPTION
Since aae8cea0f60b03077d2283a356ff89a285c3b134 the gem no longer depends on the RuboCop config from Beaker, so version 4 works again.