### PR TITLE
Use shorter directory names for beaker-hostgenerator

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -204,8 +204,12 @@ module Beaker
       @options = options
       @logger = options[:logger]
       @hosts = vagrant_hosts
-      @vagrant_path = File.expand_path(File.join('.vagrant', 'beaker_vagrant_files',
-                                                 'beaker_' + File.basename(options[:hosts_file])))
+      vagrant_directory = if options[:hosts_file_generated]
+                            "beaker_hostgenerator_#{@hosts.map(&:name).join('-')}"
+                          else
+                            "beaker_#{File.basename(options[:hosts_file])}"
+                          end
+      @vagrant_path = File.expand_path(File.join('.vagrant', 'beaker_vagrant_files', vagrant_directory))
       @vagrant_file = File.expand_path(File.join(@vagrant_path, 'Vagrantfile'))
       @vagrant_env = {}
     end


### PR DESCRIPTION
When the Beaker setfile doesn't exist, Beaker calls beaker-hostgenerator and sets the :hosts_file_generated option. These directory names can become very long and in some cases exceed some limits when used with vagrant-libvirt.

This only uses the hostnames and discards all options passed. This can break some scenarios where a host is reused and a user may assume that passing in new options changes the host.

Currently a draft to test if it resolves the `Call to virDomainCreateWithFlags failed: Invalid machine name` error reported in https://github.com/voxpupuli/gha-puppet/pull/49#issuecomment-1906247620