### PR TITLE
Gemfile: add faraday as GCG dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,10 @@
+# frozen_string_literal: true
+
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 gemspec
+
 group :release do
-  gem 'github_changelog_generator', require: false
+  gem 'faraday-retry', '~> 2.1', require: false
+  gem 'github_changelog_generator', '~> 1.16.4', require: false
 end


### PR DESCRIPTION
It's an optional dependency of GCG and we get warnings if it's missing. We added it to other repos as well.